### PR TITLE
Adapt GridExtpar to new JSON format

### DIFF
--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -8,7 +8,7 @@ pipeline {
     }
     options {
         skipDefaultCheckout()
-        timeout(time: 1, unit: 'HOURS')
+        timeout(time: 2, unit: 'HOURS')
     }
     parameters {
         booleanParam(name: 'DEBUG_MODE', defaultValue: false, description: 'Toggle debug mode on to always retain the workspace at the end of the pipeline.')

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '192', '193'
+                        values '195', '196', '197'
                     }
                 }
                 agent {

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '127', '128', '129' , '131'
+                        values '192'
                     }
                 }
                 agent {

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '192'
+                        values '192', '192'
                     }
                 }
                 agent {

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '192', '192'
+                        values '192', '193'
                     }
                 }
                 agent {

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -76,7 +76,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
         logging.info(f"Processing in {extpar_dir}")
 
         # Extract the EXTPAR part of the domain and save it as a domain-specific config.json
-        domain_extpar_config = domain["extpar"]
+        domain_extpar_config = {"extpar": domain["extpar"]}
         domain_config_path = os.path.join(extpar_dir, 'config.json')
         with open(domain_config_path, 'w') as f:
             json.dump(domain_extpar_config, f, indent=4)

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -213,7 +213,7 @@ def write_gridgen_namelist(config, wrk_dir):
         namelist.append("")
 
         # local domain
-        if domain["region_type"] == 3:
+        if icontools["region_type"] == 3:
             namelist.append(f"  dom({i+1})%center_lon   = {icontools.get('center_lon',0.0)}")
             namelist.append(f"  dom({i+1})%center_lat   = {icontools.get('center_lat',0.0)}")
             namelist.append(f"  dom({i+1})%hwidth_lon   = {icontools.get('hwidth_lon',0.0)}")
@@ -226,7 +226,7 @@ def write_gridgen_namelist(config, wrk_dir):
             namelist.append("")
 
         # circular domain
-        if domain["region_type"] == 2:
+        if icontools["region_type"] == 2:
             namelist.append(f"  dom({i+1})%center_lon   = {icontools.get('center_lon',0.0)}")
             namelist.append(f"  dom({i+1})%center_lat   = {icontools.get('center_lat',0.0)}")
             namelist.append(f"  dom({i+1})%radius       = {icontools.get('radius',0.0)}")

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -205,7 +205,7 @@ def write_gridgen_namelist(config, wrk_dir):
 
     # tuning parameters
     namelist.append(f"  lspring_dynamics = .{str(config.get('lspring_dynamics',True)).upper()}.")
-    namelist.append(f"  maxit = {config.get('maxit', 500)}")
+    namelist.append(f"  maxit = {config.get('maxit', 2000)}")
     namelist.append(f"  beta_spring = {config.get('beta_spring', 0.9)}")
     namelist.append("")
     

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -206,7 +206,7 @@ def write_gridgen_namelist(config, wrk_dir):
     for i, domain in enumerate(domains):
         icontools = domain["icontools"]
         lwrite_parent = i == 0
-        namelist.append(f"  dom({i+1})%outfile             = \"{basegrid('outfile')}\" ")
+        namelist.append(f"  dom({i+1})%outfile             = \"{basegrid['outfile']}\" ")
         namelist.append(f"  dom({i+1})%lwrite_parent       = .{str(lwrite_parent).upper()}.")
         namelist.append(f"  dom({i+1})%region_type         = {icontools['region_type']}")
         namelist.append(f"  dom({i+1})%number_of_grid_used = {icontools.get('number_of_grid_used',0)}")

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -86,7 +86,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
 
         shell_cmd(
             "podman", "run",
-            "-e", "OMP_NUM_THREADS=16",
+            "-e", "OMP_NUM_THREADS=32",
             "-v", "/net/co2/c2sm-data/extpar-input-data:/data",
             "-v", f"{workspace}/icontools:/grid",
             "-v", f"{extpar_dir}:/work",

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -273,7 +273,7 @@ def main(workspace, config_path):
     # Load config and write namelist
     config = load_config(config_path)
 
-    grid_files = run_icontools(workspace, config['icontools'])
+    grid_files = run_icontools(workspace, config)
 
     extpar_tag = pull_extpar_image(config['zonda'])
 

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -95,7 +95,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
         logging.info(f"Running podman command for extpar in {extpar_dir}")
         shell_cmd(
             "podman", "run",
-            "-e", "OMP_NUM_THREADS=32",
+            "-e", "OMP_NUM_THREADS=24",
             "-v", "/net/co2/c2sm-data/extpar-input-data:/data",
             "-v", f"{workspace}/icontools:/grid",
             "-v", f"{extpar_dir}:/work",

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -232,7 +232,7 @@ def write_gridgen_namelist(config, wrk_dir):
             namelist.append(f"  dom({i+1})%radius       = {icontools.get('radius',0.0)}")
             namelist.append("")
         
-        grid_files.append(f"{config.get('outfile')}_{dom_id_to_str(i)}.nc")
+        grid_files.append(f"{basegrid['outfile']}_{dom_id_to_str(i)}.nc")
 
     namelist.append("/")
     namelist.append("")

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -67,8 +67,16 @@ def move_output(workspace, grid_files, extpar_dirs, keep_base_grid):
     create_zip(zip_file_path, output_dir)
 
 def run_extpar(workspace, config_path, grid_files, extpar_tag):
+    logging.info(f"Call run_extpar with the following arguments:\n"
+                 f"workspace: {workspace}\n"
+                 f"config_path: {config_path}\n"
+                 f"grid_files: {grid_files}\n"
+                 f"extpar_tag: {extpar_tag}")
+    # Create the EXTPAR directories
     extpar_dirs = []
     config = load_config(config_path)
+    logging.info("Configuration loaded")
+    logging.info(config)
 
     for i, domain in enumerate(config["domains"]):
         extpar_dir = os.path.join(workspace, f"extpar_{dom_id_to_str(i)}")
@@ -84,6 +92,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
 
         os.chdir(extpar_dir)        
 
+        logging.info(f"Running podman command for extpar in {extpar_dir}")
         shell_cmd(
             "podman", "run",
             "-e", "OMP_NUM_THREADS=32",

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -172,6 +172,9 @@ def write_gridgen_namelist(config, wrk_dir):
     basegrid = config["basegrid"]
     domains = config["domains"]
     
+    # Ensure the first domain has parent_id = 0
+    domains[0]["icontools"]["parent_id"] = 0
+    
     # Set default values
     parent_id = ",".join(str(domain["icontools"]["parent_id"]) for domain in domains)
     initial_refinement = True


### PR DESCRIPTION
This PR adapts the `GridExtpar.py` wrapper to the new JSON format from the frontend `v0.4`. Additionally, three new testcases are defined, which are the presets from the frontend. For that, the walltime for the testsuite had to be increased to 2 hours. To speed up other parts, the number of OMP threads is increased from 16 to 24.