### PR TITLE
Include namelists in output.zip

### DIFF
--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -8,7 +8,7 @@ pipeline {
     }
     options {
         skipDefaultCheckout()
-        timeout(time: 1, unit: 'HOURS')
+        timeout(time: 2, unit: 'HOURS')
     }
     parameters {
         booleanParam(name: 'DEBUG_MODE', defaultValue: false, description: 'Toggle debug mode on to always retain the workspace at the end of the pipeline.')

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '192', '193'
+                        values '195', '196', '197'
                     }
                 }
                 agent {

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '127', '128', '129' , '131'
+                        values '192'
                     }
                 }
                 agent {

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '192'
+                        values '192', '192'
                     }
                 }
                 agent {

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '192', '192'
+                        values '192', '193'
                     }
                 }
                 agent {

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -76,7 +76,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
         logging.info(f"Processing in {extpar_dir}")
 
         # Extract the EXTPAR part of the domain and save it as a domain-specific config.json
-        domain_extpar_config = domain["extpar"]
+        domain_extpar_config = {"extpar": domain["extpar"]}
         domain_config_path = os.path.join(extpar_dir, 'config.json')
         with open(domain_config_path, 'w') as f:
             json.dump(domain_extpar_config, f, indent=4)

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -213,7 +213,7 @@ def write_gridgen_namelist(config, wrk_dir):
         namelist.append("")
 
         # local domain
-        if domain["region_type"] == 3:
+        if icontools["region_type"] == 3:
             namelist.append(f"  dom({i+1})%center_lon   = {icontools.get('center_lon',0.0)}")
             namelist.append(f"  dom({i+1})%center_lat   = {icontools.get('center_lat',0.0)}")
             namelist.append(f"  dom({i+1})%hwidth_lon   = {icontools.get('hwidth_lon',0.0)}")
@@ -226,7 +226,7 @@ def write_gridgen_namelist(config, wrk_dir):
             namelist.append("")
 
         # circular domain
-        if domain["region_type"] == 2:
+        if icontools["region_type"] == 2:
             namelist.append(f"  dom({i+1})%center_lon   = {icontools.get('center_lon',0.0)}")
             namelist.append(f"  dom({i+1})%center_lat   = {icontools.get('center_lat',0.0)}")
             namelist.append(f"  dom({i+1})%radius       = {icontools.get('radius',0.0)}")

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -205,7 +205,7 @@ def write_gridgen_namelist(config, wrk_dir):
 
     # tuning parameters
     namelist.append(f"  lspring_dynamics = .{str(config.get('lspring_dynamics',True)).upper()}.")
-    namelist.append(f"  maxit = {config.get('maxit', 500)}")
+    namelist.append(f"  maxit = {config.get('maxit', 2000)}")
     namelist.append(f"  beta_spring = {config.get('beta_spring', 0.9)}")
     namelist.append("")
     

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -206,7 +206,7 @@ def write_gridgen_namelist(config, wrk_dir):
     for i, domain in enumerate(domains):
         icontools = domain["icontools"]
         lwrite_parent = i == 0
-        namelist.append(f"  dom({i+1})%outfile             = \"{basegrid('outfile')}\" ")
+        namelist.append(f"  dom({i+1})%outfile             = \"{basegrid['outfile']}\" ")
         namelist.append(f"  dom({i+1})%lwrite_parent       = .{str(lwrite_parent).upper()}.")
         namelist.append(f"  dom({i+1})%region_type         = {icontools['region_type']}")
         namelist.append(f"  dom({i+1})%number_of_grid_used = {icontools.get('number_of_grid_used',0)}")

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -86,7 +86,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
 
         shell_cmd(
             "podman", "run",
-            "-e", "OMP_NUM_THREADS=16",
+            "-e", "OMP_NUM_THREADS=32",
             "-v", "/net/co2/c2sm-data/extpar-input-data:/data",
             "-v", f"{workspace}/icontools:/grid",
             "-v", f"{extpar_dir}:/work",

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -273,7 +273,7 @@ def main(workspace, config_path):
     # Load config and write namelist
     config = load_config(config_path)
 
-    grid_files = run_icontools(workspace, config['icontools'])
+    grid_files = run_icontools(workspace, config)
 
     extpar_tag = pull_extpar_image(config['zonda'])
 

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -95,7 +95,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
         logging.info(f"Running podman command for extpar in {extpar_dir}")
         shell_cmd(
             "podman", "run",
-            "-e", "OMP_NUM_THREADS=32",
+            "-e", "OMP_NUM_THREADS=24",
             "-v", "/net/co2/c2sm-data/extpar-input-data:/data",
             "-v", f"{workspace}/icontools:/grid",
             "-v", f"{extpar_dir}:/work",

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -232,7 +232,7 @@ def write_gridgen_namelist(config, wrk_dir):
             namelist.append(f"  dom({i+1})%radius       = {icontools.get('radius',0.0)}")
             namelist.append("")
         
-        grid_files.append(f"{config.get('outfile')}_{dom_id_to_str(i)}.nc")
+        grid_files.append(f"{basegrid['outfile']}_{dom_id_to_str(i)}.nc")
 
     namelist.append("/")
     namelist.append("")

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -67,8 +67,16 @@ def move_output(workspace, grid_files, extpar_dirs, keep_base_grid):
     create_zip(zip_file_path, output_dir)
 
 def run_extpar(workspace, config_path, grid_files, extpar_tag):
+    logging.info(f"Call run_extpar with the following arguments:\n"
+                 f"workspace: {workspace}\n"
+                 f"config_path: {config_path}\n"
+                 f"grid_files: {grid_files}\n"
+                 f"extpar_tag: {extpar_tag}")
+    # Create the EXTPAR directories
     extpar_dirs = []
     config = load_config(config_path)
+    logging.info("Configuration loaded")
+    logging.info(config)
 
     for i, domain in enumerate(config["domains"]):
         extpar_dir = os.path.join(workspace, f"extpar_{dom_id_to_str(i)}")
@@ -84,6 +92,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
 
         os.chdir(extpar_dir)        
 
+        logging.info(f"Running podman command for extpar in {extpar_dir}")
         shell_cmd(
             "podman", "run",
             "-e", "OMP_NUM_THREADS=32",

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -172,6 +172,9 @@ def write_gridgen_namelist(config, wrk_dir):
     basegrid = config["basegrid"]
     domains = config["domains"]
     
+    # Ensure the first domain has parent_id = 0
+    domains[0]["icontools"]["parent_id"] = 0
+    
     # Set default values
     parent_id = ",".join(str(domain["icontools"]["parent_id"]) for domain in domains)
     initial_refinement = True

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -17,21 +17,30 @@ def move_files(src_pattern, dest_dir, prefix="",blacklist={}):
         shutil.move(file, dest_file)
 
 
-def move_extpar(dest, grid_files, extpar_dirs):
+def move_extpar(output_dir, namelist_dir, grid_files, extpar_dirs):
     for i, exptar_dir in enumerate(extpar_dirs):
         # Move logfiles
-        move_files(os.path.join(exptar_dir, "*.log"), os.path.join(dest, 'logs'), f"{dom_id_to_str(i)}_")
-        # Move external parameter file
+        move_files(os.path.join(exptar_dir, "*.log"), os.path.join(output_dir, 'logs'), f"{dom_id_to_str(i)}_")
+        # Move external parameter files
         grid_file_base = os.path.splitext(grid_files[i])[0]  # Drop the suffix ".nc"
-        move_files(os.path.join(exptar_dir, "external_parameter.nc"), dest, f"{grid_file_base}_")
+        move_files(os.path.join(exptar_dir, "external_parameter.nc"), output_dir, f"{grid_file_base}_")
+        # Create directories for each domain
+        domain_dir = os.path.join(namelist_dir, dom_id_to_str(i))
+        os.makedirs(os.path.join(domain_dir), exist_ok=True)
+        move_files(os.path.join(exptar_dir, "INPUT_*"), domain_dir)
+        move_files(os.path.join(exptar_dir, "namelist.py"), domain_dir)
+        move_files(os.path.join(exptar_dir, "config.json"), domain_dir)
 
-def move_icontools(workspace, dest, keep_base_grid):
+
+def move_icontools(workspace, output_dir, namelist_dir, keep_base_grid):
     # too big for high-res grids
     blacklist = {} if keep_base_grid else {'base_grid.nc', 'base_grid.html'}
     # Move .nc files
-    move_files(os.path.join(workspace, 'icontools', '*.nc'), os.path.join(dest), blacklist=blacklist)
+    move_files(os.path.join(workspace, 'icontools', '*.nc'), os.path.join(output_dir), blacklist=blacklist)
     # Move .html files
-    move_files(os.path.join(workspace, 'icontools', '*.html'), dest, blacklist=blacklist)
+    move_files(os.path.join(workspace, 'icontools', '*.html'), output_dir, blacklist=blacklist)
+    # Move namelist file
+    move_files(os.path.join(workspace, 'icontools', 'nml_gridgen'), namelist_dir)
 
 
 def create_zip(zip_file_path, source_dir):
@@ -43,34 +52,30 @@ def create_zip(zip_file_path, source_dir):
                 arcname = os.path.relpath(file_path, source_dir)
                 zipf.write(file_path, arcname)
 
+
 def move_output(workspace, grid_files, extpar_dirs, keep_base_grid):
     logging.info(f"move_output called with workspace: {workspace}, grid_files: {grid_files}, extpar_dirs: {extpar_dirs}, keep_base_grid: {keep_base_grid}")
     
     output_dir = os.path.join(workspace, 'output')
     log_dir = os.path.join(output_dir, 'logs')
+    namelist_dir = os.path.join(output_dir, 'namelists')
 
     # Ensure the output directory exists
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(log_dir, exist_ok=True)
+    os.makedirs(namelist_dir, exist_ok=True)
 
     # Move extpar files
-    move_extpar(output_dir, grid_files, extpar_dirs)
+    move_extpar(output_dir, namelist_dir, grid_files, extpar_dirs)
 
     # Move icontools files
-    move_icontools(workspace, output_dir, keep_base_grid)
-
-    # Copy the namelist file to the output directory
-    namelist_file = os.path.join(workspace, 'icontools', 'nml_gridgen')
-    if os.path.exists(namelist_file):
-        shutil.copy(namelist_file, output_dir)
-        logging.info(f"Namelist file {namelist_file} copied to {output_dir}")
-    else:
-        logging.warning(f"Namelist file {namelist_file} not found")
+    move_icontools(workspace, output_dir, namelist_dir, keep_base_grid)
 
     # Create a zip file
     zip_file_path = os.path.join(workspace, 'output.zip')
     create_zip(zip_file_path, output_dir)
     logging.info(f"Output zip file created at {zip_file_path}")
+
 
 def run_extpar(workspace, config_path, grid_files, extpar_tag):
     logging.info(f"Call run_extpar with the following arguments:\n"
@@ -120,6 +125,7 @@ def run_extpar(workspace, config_path, grid_files, extpar_tag):
     os.chdir(workspace)
     logging.info("Extpar completed")
     return extpar_dirs
+
 
 def run_gridgen(wrk_dir):
     shell_cmd("podman", "run", "-w", "/work", "-u", "0", "-v", f"{wrk_dir}:/work", "-e", "LD_LIBRARY_PATH=/home/dwd/software/lib", "-t", "execute:latest-master", "/home/dwd/icontools/icongridgen", "--nml", "/work/nml_gridgen")
@@ -175,12 +181,14 @@ def shell_cmd(bin, *args):
 
     return output
 
+
 def load_config(config_file):
     logging.info(f"Loading configuration from {config_file}")
     with open(config_file, 'r') as f:
         config = json.load(f)
     logging.info("Configuration loaded successfully")
     return config
+
 
 def write_gridgen_namelist(config, wrk_dir):
     logging.info("Writing gridgen namelist")
@@ -263,8 +271,10 @@ def write_gridgen_namelist(config, wrk_dir):
 
     return grid_files
 
+
 def dom_id_to_str(dom_id):
     return f"DOM{dom_id+1:02d}"
+
 
 def run_icontools(workspace, config):
     logging.info(f"Number of domains: {len(config['domains'])}")
@@ -279,11 +289,13 @@ def run_icontools(workspace, config):
 
     return grid_files
 
+
 def pull_extpar_image(config):
     tag = config['extpar_tag']
     shell_cmd("podman", "pull", f"docker.io/c2sm/extpar:{tag}")
     logging.info("Pull extpar image completed")
     return tag
+
 
 def main(workspace, config_path):
     logging.info(f"Starting main process with workspace: {workspace} and config_path: {config_path}")
@@ -301,6 +313,7 @@ def main(workspace, config_path):
     move_output(workspace, grid_files, extpar_dirs, keep_base_grid)
 
     logging.info("Process completed")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Setup workspace and generate namelist")

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -44,7 +44,8 @@ def create_zip(zip_file_path, source_dir):
                 zipf.write(file_path, arcname)
 
 def move_output(workspace, grid_files, extpar_dirs, keep_base_grid):
-
+    logging.info(f"move_output called with workspace: {workspace}, grid_files: {grid_files}, extpar_dirs: {extpar_dirs}, keep_base_grid: {keep_base_grid}")
+    
     output_dir = os.path.join(workspace, 'output')
     log_dir = os.path.join(output_dir, 'logs')
 
@@ -52,19 +53,24 @@ def move_output(workspace, grid_files, extpar_dirs, keep_base_grid):
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(log_dir, exist_ok=True)
 
-    logging.info(f"Output directory: {output_dir}")
-
     # Move extpar files
     move_extpar(output_dir, grid_files, extpar_dirs)
 
     # Move icontools files
     move_icontools(workspace, output_dir, keep_base_grid)
 
+    # Copy the namelist file to the output directory
+    namelist_file = os.path.join(workspace, 'icontools', 'nml_gridgen')
+    if os.path.exists(namelist_file):
+        shutil.copy(namelist_file, output_dir)
+        logging.info(f"Namelist file {namelist_file} copied to {output_dir}")
+    else:
+        logging.warning(f"Namelist file {namelist_file} not found")
+
     # Create a zip file
     zip_file_path = os.path.join(workspace, 'output.zip')
-
-    
     create_zip(zip_file_path, output_dir)
+    logging.info(f"Output zip file created at {zip_file_path}")
 
 def run_extpar(workspace, config_path, grid_files, extpar_tag):
     logging.info(f"Call run_extpar with the following arguments:\n"


### PR DESCRIPTION
This PR adds namelist files of ICONTools and EXTPAR to the final `output.zip` file as this was requested by several beta testers.

A new folder `namelists` is created. There one finds:
- `nml_gridgen`
- directories for each domain (`DOM01`, `DOM02`, etc.), containing the following files
    - `INPUT_*`
    - `namlist.py`
    - `config.json`
  