### PR TITLE
Capture ICON Tools and EXTPAR logs correctly

### DIFF
--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '235', '215'
+                        values '195', '196', '197'
                     }
                 }
                 agent {

--- a/jenkins/Testsuite
+++ b/jenkins/Testsuite
@@ -19,7 +19,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ISSUE_ID'
-                        values '195', '196', '197'
+                        values '235', '215'
                     }
                 }
                 agent {

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -168,7 +168,7 @@ def shell_cmd(bin, *args):
         raise
 
     except subprocess.CalledProcessError as e:
-        output = e.stderr
+        output = e.stdout + e.stderr
         logging.warning(f'Problems with shell command: {args_for_logger} \n'
                         '-> the output returned to the shell is:')
         logging.warning(f'{output}')

--- a/src/GridExtpar.py
+++ b/src/GridExtpar.py
@@ -326,7 +326,7 @@ if __name__ == "__main__":
     # setup logger
     format = "%(asctime)s - %(levelname)s - %(message)s"
     if args.logfile:
-        logging.basicConfig(filename=args.logfile, format=format, level=logging.INFO)
+        logging.basicConfig(filename=args.logfile, filemode='w', format=format, level=logging.INFO)
     else:
         logging.basicConfig(format=format, level=logging.INFO)
 


### PR DESCRIPTION
This MR is an attempt to fix the issue where the output of ICON Tools and EXTPAR is not captured in case of a `CalledProcessError` exception. This results in the *gridextpar.log* file not containing any error messages regarding the underlying issue.

To fix this problem it seems we have to output both *stdout* and *stderr*, instead of just the *stderr*.

Additionally, I changed the output mode to *gridextpar.log* to "write" instead of the default "append".